### PR TITLE
Fix adafruit1306 update

### DIFF
--- a/WiFiOSC.ino
+++ b/WiFiOSC.ino
@@ -46,17 +46,21 @@
 #include <OSCData.h>
 #include <Wire.h>
 #include "SPI.h"
+#include <Adafruit_I2CDevice.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include "MORAD_IO.h"
-#include "DAC.H"
+#include "DAC.h"
 #include "MORAD_utility.h"
 
-#define OLED_RESET -1  // to keep the compiler happy
-Adafruit_SSD1306 display(OLED_RESET);
+#define OLED_RESET -1  // sharing with reset pin
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 32
 
-char ssid[] = "your_SSID";          // your network SSID (name)
-char pass[] = "your_password";      // your network password
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+char ssid[] = "smithhouse";          // your network SSID (name)
+char pass[] = "SM1THH@U5";      // your network password
 
 // A UDP instance to let us send and receive packets over UDP
 WiFiUDP Udp;

--- a/WiFiOSC.ino
+++ b/WiFiOSC.ino
@@ -59,8 +59,8 @@
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
-char ssid[] = "smithhouse";          // your network SSID (name)
-char pass[] = "SM1THH@U5";      // your network password
+char ssid[] = "your_network_ssid";          // your network SSID (name)
+char pass[] = "your_network_password";      // your network password
 
 // A UDP instance to let us send and receive packets over UDP
 WiFiUDP Udp;

--- a/WiFiOSC.ino
+++ b/WiFiOSC.ino
@@ -59,8 +59,8 @@
 
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
-char ssid[] = "your_network_ssid";          // your network SSID (name)
-char pass[] = "your_network_password";      // your network password
+char ssid[] = "your_SSID";          // your network SSID (name)
+char pass[] = "your_password";      // your network password
 
 // A UDP instance to let us send and receive packets over UDP
 WiFiUDP Udp;


### PR DESCRIPTION
Looks like the Adafruit_1306 lib has been updated to require height/width for running the display.  I'm building with platformio, so there may be minor differences ... could probably use someone testing a build via Arduino, but things look good to me, module is processing OSC as expected.